### PR TITLE
Enable comment toggling functionality

### DIFF
--- a/Earthfile.tmPreferences
+++ b/Earthfile.tmPreferences
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>name</key>
+  <string>Comments</string>
+  <key>scope</key>
+  <string>source.earthfile</string>
+  <key>settings</key>
+  <dict>
+    <key>shellVariables</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_START</string>
+        <key>value</key>
+        <string># </string>
+      </dict>
+    </array>
+  </dict>
+</dict></plist>

--- a/Earthfile.tmPreferences
+++ b/Earthfile.tmPreferences
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-  <key>name</key>
-  <string>Comments</string>
-  <key>scope</key>
-  <string>source.earthfile</string>
-  <key>settings</key>
+<plist version="1.0">
   <dict>
-    <key>shellVariables</key>
-    <array>
-      <dict>
-        <key>name</key>
-        <string>TM_COMMENT_START</string>
-        <key>value</key>
-        <string># </string>
-      </dict>
-    </array>
+    <key>name</key>
+    <string>Comments</string>
+    <key>scope</key>
+    <string>source.earthfile</string>
+    <key>settings</key>
+    <dict>
+      <key>shellVariables</key>
+      <array>
+        <dict>
+          <key>name</key>
+          <string>TM_COMMENT_START</string>
+          <key>value</key>
+          <string># </string>
+        </dict>
+      </array>
+    </dict>
   </dict>
-</dict></plist>
+</plist>

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ For an introduction of Earthly see the [Earthly GitHub repository](https://githu
 ### For Sublime 3
 
 * From Sublime -> `Preferences` -> `Browse Packages` -> This will open a directory
-* Copy the `Earthfile.tmLanguage` inside this directory and the syntax will be added to Sublime
+* Copy the `Earthfile.tmLanguage` and `Earthfile.tmPreferences` inside this directory and the syntax will be added to Sublime
 * After this, new Earthfiles that you open will have the syntax highlighted, and for the already opened earthfiles, either reopen it, or restart sublime, or select `View` -> `Syntax` -> `Earthfile`
 
 ### For Sublime 2
 
 * From Sublime -> `Preferences` -> `Browse Packages`
 * It will open a directory similar to `<Installation Directory>\Data\Packages`
-* It will have a lot of dircetories with language names such as `C++`, `Java`, `Python` and many more.  We need to create a folder called `Earthfile` and copy the `Earthfile.tmLanguage` inside the newly created directory
+* It will have a lot of dircetories with language names such as `C++`, `Java`, `Python` and many more.  We need to create a folder called `Earthfile` and copy the `Earthfile.tmLanguage` and `Earthfile.tmPreferences` inside the newly created directory
 * After this, new Earthfiles that you open will have the syntax highlighted, and for the already opened earthfiles, either reopen it, or restart sublime, or select `View` -> `Syntax` -> `Earthfile`
 
 ## Screenshot


### PR DESCRIPTION
Created an `Earthly.tmPreferences` file which enables the `Toggle Comment` menu functionality and keyboard shortcut in sublimetext.